### PR TITLE
Output as texture in next frame and milkglass shader

### DIFF
--- a/data/examples/milkglass-3x3.shader
+++ b/data/examples/milkglass-3x3.shader
@@ -1,0 +1,277 @@
+// prev_output_image is a special cased texture2d which always contains
+// the result of the last render pass. It is used to retain some state 
+// so we can create a more stable final color.
+uniform texture2d prev_output_image;
+
+uniform string Description<
+    string widget_type = "info";
+> = "Calculates a simple 3x3 color grid based on the source image. It can \
+record colors up to 40 seconds to provide stable colors. It can be used as \
+ambient color for your background overlay or to hide your screen without \
+turning your stream black. See configuration instructions below.";
+
+uniform float4 bright_color<
+    string label = "Bright Color";
+> = {0.188, 0.58, 1.0, 1};
+
+uniform float lumaMax<
+    string label = "Luma Max";
+    string widget_type = "slider";
+    float minimum = 0.0;
+    float maximum = 1.0;
+    float step = 0.001;
+> = 0.55;
+
+uniform float4 dark_color<
+    string label = "Dark Color";
+> = {0.043, 0.1372, 0.2392, 1};
+
+uniform string dark_hint<
+    string widget_type = "info";
+    string label = " ";
+> = "Used when the color is above the maximum luminance.";
+
+uniform float lumaMin<
+    string label = "Luma Min";
+    string widget_type = "slider";
+    float minimum = 0.0;
+    float maximum = 1.0;
+    float step = 0.001;
+> = 0.05;
+
+uniform string bright_hint<
+    string widget_type = "info";
+    string label = " ";
+> = "Used when the color is below the minimum luminance.";
+
+uniform string limit_hint<
+    string widget_type = "info";
+    string label = " ";
+> = "If you want to apply the luminance limits to the history \
+values or on the final value. This may need experimentation on your \
+side, but only final value should be enough:";
+
+uniform bool limit_history_value<
+    string label = "Luma limit: history value";
+    string widget_type = "checkbox";
+>= false;
+
+uniform bool limit_final_value<
+    string label = "Luma limit: final value";
+    string widget_type = "checkbox";
+>= true;
+
+uniform string seconds_hint<
+    string widget_type = "info";
+    string label = " ";
+> = "You can stabilize the generated color by using the history values. \
+The history can contain color values. Up to 2400 frames, resulting in \
+a total of 40 seconds.";
+
+uniform float seconds<
+    string label = "Seconds (60 FPS)";
+    string widget_type = "slider";
+    float minimum = 0.0;
+    float maximum = 40.0;
+    float step = 0.0166;
+> = 3;
+
+uniform string Guide<
+    string widget_type = "info";
+> = "1. Create a new 'Color Source' with a full transparent black color.\n\
+2. Open the filters settings of this new 'Color Source'.\n\
+3. Add a new filter 'User definied shader' named 'Copy', check 'Load shader text from file' and selected 'Add.shader' from the examples folder. \
+Select on the line 'other image' your source which you want to create the background from.\n\
+4. Add a new filter 'Scaling/Aspect Ratio' with resolution '284x160', which will significantly reduce GPU load.\n\
+5. Add a another 'User defined shader' named 'milkglass 3x3', check 'Load shader text from file' and pick 'milkglass-3x3.shader' from the examples folder. \
+Keep the other setting as they are for now.\n\
+6. Add a new filter 'Crop/Pad' named 'Pick stable colors'. Uncheck the relative checkbox and set X: 5, Y: 5, Width: 3, Height: 3.\n\
+7. Now you can see how the colors are changing over time. If you right-click on the 'Color Source' and change \
+the 'Scale Filtering' to 'Bicubic', you can get an even nicer gradient. If you set the it to 'Point' or 'Area' you can see the actual colors.\n\
+8. In the 'milkglass 3x3' shader you can adjust some settings to your use case. For example, you can make it more or less stable by adjusting the 'Seconds' parameter. \
+If you have it set to 0 seconds, it only takes the colors of the current frame. The higher the value, the more frames it will use to stabilize the final colors. This \
+reduces flickering of the background when small portions on the screens are getting suddenly bright.";
+
+float4 calculateNewPixel(int pixelX, int pixelY) 
+{
+    // Calculate the start and end range for X axis.
+    float tileWidth = uv_size.x / 3.0;
+    float tileHeight = uv_size.y / 3.0;
+    int xStart = int(pixelX * tileWidth);
+    int xEnd = int((pixelX + 1) * tileWidth);
+    int yStart = int(pixelY * tileHeight);
+    int yEnd = int((pixelY + 1) * tileHeight);
+
+    // The full color value is always centered within the pixel. 
+    // Therefore, 0.5, 0.5 represents the top-left corner with the fully colored pixel. 
+    // If 0.0, 0.0 was chosen, it would look half-transparent.
+    float widthMinus1 = uv_size.x - 1;
+    float heightMinus1 = uv_size.y - 1;
+    float xOffset = 0.5 / uv_size.x;
+    float yOffset = 0.5 / uv_size.y;
+
+    // Prepare variables for averaging values.
+    float transparent = 0.0;
+    int count = 0;
+    float samples = 0.0;
+    float4 c = float4(0.0, 0.0, 0.0, 0.0);
+
+    // Iterate over all pixels in the current tile and
+    // fill values for the average beforehand.
+    [loop] for (int y = int(yStart); y < yEnd; y++) {
+        float yf = float(y) / uv_size.y + yOffset;
+    	[loop] for (int x = int(xStart); x < xEnd; x++) {
+            float xf = float(x) / uv_size.x + xOffset;
+            float4 sc = image.Sample(textureSampler, float2(xf, yf));
+
+            transparent += sc.a;
+			count++;
+            c += sc * sc.a;
+            samples += sc.a;
+        }
+    }
+
+    // Create an average for the opaque color value
+    if (samples > 0.0)
+        c /= samples;
+
+    // Adjust the transparency value separately
+    if (count > 0)
+        transparent = transparent / float(count); 
+    else
+        transparent = 1;
+
+    // This block recolorss dark and bright areas.
+    if (limit_history_value)
+    {
+        c *= transparent;
+        c.a = 1;
+
+        float luminance = c.r * 0.299 + c.g * 0.587 + c.b * 0.114;
+
+        if (luminance < lumaMin) {
+            c = lerp(dark_color, c, luminance / lumaMin);
+        } else if (luminance > lumaMax) {
+            c = lerp(c, bright_color, (luminance - lumaMax) / (1.0 - lumaMax));
+        }        
+    }
+    else
+    {
+        c.a = transparent;
+    }
+
+    return c;
+}
+
+float4 combineHistory(int pixelX, int pixelY) 
+{
+    if (seconds == 0) {
+        return calculateNewPixel(pixelX - 5, pixelY - 5);
+    }
+
+    // Calculate the relative pixel position within the tile
+    pixelX -= 5;
+    pixelY += 5;
+
+    // The full color value is always in the center of the pixel. 
+    // So 0.5, 0.5 is the top left corner with the fully colored pixel. 
+    // If 0.0, 0.0 was chosen, it would look half-transparent.
+    float xOffset = 0.5 / uv_size.x;
+    float yOffset = 0.5 / uv_size.y;
+    int maxCount = int(seconds * 60);
+
+    // Prepare variables for averaging values.
+    float transparent = 0.0;
+    int count = 0;
+    float samples = 0.0;
+    float4 c = float4(0.0, 0.0, 0.0, 0.0);
+
+    // Iterate over all pixels in the current tile and
+    // fill values for the average beforehand.
+    [loop] for (int y = 0; y < 48 && count < maxCount; y++) {
+        float yf = float(y * 3 + pixelY) / uv_size.y + yOffset;
+    	[loop] for (int x = 0; x < 50 && count < maxCount; x++) {
+            float xf = float(x * 3 + pixelX) / uv_size.x + xOffset;
+            float4 sc = prev_output_image.Sample(textureSampler, float2(xf, yf));
+
+            transparent += sc.a;
+			count++;
+            c += sc * sc.a;
+            samples += sc.a;
+        }
+    }
+
+    // Create an average for the opaque color value
+    if (samples > 0.0)
+        c /= samples;
+
+    // Adjust the transparency value separately
+    if (count > 0)
+        transparent = transparent / float(count);
+    else
+        transparent = 1;
+
+    // This block recolorss dark and bright areas.
+    if (limit_final_value)
+    {
+        c *= transparent;
+        c.a = 1;
+
+        float luminance = c.r * 0.299 + c.g * 0.587 + c.b * 0.114;
+
+        if (luminance < lumaMin) {
+            c = lerp(dark_color, c, luminance / lumaMin);
+        } else if (luminance > lumaMax) {
+            c = lerp(c, bright_color, (luminance - lumaMax) / (1.0 - lumaMax));
+        }
+    }
+    else 
+    {
+        c.a = transparent;
+    }
+
+    return c;
+}
+
+float4 executeMove(int pixelX, int pixelY)
+{
+    if (pixelX <= 2)
+    {
+        // We are already on the most left side. Go one row up.
+        pixelX = 153 + pixelX;
+        pixelY -= 3;
+    }
+    else 
+    {
+        // Select the pixels in the tile to the left.
+        pixelX -= 3;
+    }
+
+    float xOffset = 0.5 / uv_size.x;
+    float yOffset = 0.5 / uv_size.y;
+
+    float xf = float(pixelX) / uv_size.x + xOffset;
+    float yf = float(pixelY) / uv_size.y + yOffset;
+    return prev_output_image.Sample(textureSampler, float2(xf, yf));
+}
+
+float4 mainImage(VertData v_in) : TARGET
+{
+    int pixelX = int(v_in.uv.x * uv_size.x);
+	int pixelY = int(v_in.uv.y * uv_size.y);
+    // The 3x3 pixels between (5,5) and (7,7) contain the stable colours.
+    // These colours are calculated using the average value of the entire 3x3 tiles within
+    // the history between (5,10) and (155,153) = 2400 frames / 60 = 40 sec.
+    if (pixelX >= 5 && pixelX <= 7 && pixelY >= 5 && pixelY <= 7)
+        return combineHistory(pixelX, pixelY);
+    
+    // Area that is not used and is always empty
+    if (pixelY < 10 || pixelX > 155 || pixelY > 153 || seconds == 0)
+        return float4(0,0,0,0);
+
+    // The first tile always contains the colours of the latest frame.
+    if (pixelY >= 10 && pixelY <= 12 && pixelX >= 0 && pixelX <= 2)
+        return calculateNewPixel(pixelX, pixelY - 10);
+
+    return executeMove(pixelX, pixelY);
+}

--- a/data/examples/pixel-transition.shader
+++ b/data/examples/pixel-transition.shader
@@ -1,0 +1,36 @@
+uniform texture2d prev_output_image;
+
+uniform float color_transition_step_size<
+    string label = "Color Transition Step Size";
+    string widget_type = "slider";
+    float minimum = 0.0;
+    float maximum = 255.0;
+    float step = 1.0;
+> = 1;
+
+uniform string notes<
+    string widget_type = "info";
+> = "This example demonstrates the use of the special cased texture2d 'prev_output_image`. \
+It contains always the output image of the previous frame. This is used to transform every pixel \
+to the new color separately. See milkglass-3x3.shader for a more complex example.";
+
+float step(float current, float target) {
+    if (current < target) {
+        return min(current + color_transition_step_size / 255.0, target);
+    } else {
+        return max(current - color_transition_step_size / 255.0, target);
+    }
+}
+
+float4 mainImage(VertData v_in) : TARGET
+{
+    float4 oldp = prev_output_image.Sample(textureSampler, v_in.uv);
+    float4 newp = image.Sample(textureSampler, v_in.uv);
+
+    newp.r = step(oldp.r, newp.r);
+    newp.g = step(oldp.g, newp.g);
+    newp.b = step(oldp.b, newp.b);
+    newp.a = step(oldp.a, newp.a);
+    
+    return newp;
+}


### PR DESCRIPTION
I have added another special cased parameter `prev_output_image` with type `texture2d`. It can be used in a shader file to access the output image of the previous frame. I have created a simple example `pixel-transition.shader` which uses this new parameter.

## milkglass-3x3.shader
I needed the new parameter for the new `milkglass-3x3.shader` file. Operating only one the current frame, could create the effect, but if a lot of color changes appear on the screen, it will cause a lot of flickering. To minimize flickering, i needed information of the previous frames too. I can store color information of 2400 frames (on 60 FPS about 40 seconds) in a 160x160 sized texture. This should be enough for most cases.

![end result](https://github.com/user-attachments/assets/ceb576e5-7fc3-4bd5-bced-046808262f6c)

The shader alone does not create this image. In fact it only creates an image that looks like this.
![end result shader output](https://github.com/user-attachments/assets/8ce244b5-2605-41c8-a4f0-b7b59aae5a41)

You can see this small 3x3 pixel sized tile on the top. This contains the stable color information. You crop this part at Position X: 5, Y: 5, Width: 3, Height: 3. Now you have only 3 separate colors, which you can see with Scale Filtering on `Point` or `Area`. To get the effect of the first image, you need to change Scale Filtering to `Bicubic`.

The huge pattern below contains 2400 3x3 pixel sized tiles, which is used to calculate the single tile above. If there are a lot of color changes it may look like this instead.

![changing input shader output](https://github.com/user-attachments/assets/514c8dd8-9412-4df6-9467-33271aaa7b5d)

In this example only the first 180 tiles are used to calculate the stable color tile. This can be changed in the filter settings as needed. Following parameters are available for this shader.

![shader parameters](https://github.com/user-attachments/assets/f5013875-44dc-4099-9e71-f547deec1f5a)

**Guide**
You can see the guide on the bottom. Instead of adding two capture sources, you can first copy the image from another source. To do this, you can create a full transparent black 'Color Source' and add some filters in it.

1. Color source
![Color Source](https://github.com/user-attachments/assets/f4145591-a3bf-4c9f-912f-9d8d514a17ff)
2. Add copy shader
![Copy Shader](https://github.com/user-attachments/assets/7201caf4-4c06-424d-9e29-2a8eaefec503)
3. Scale to 160p
![Scale to 160p](https://github.com/user-attachments/assets/37e43411-8e19-4e86-afd7-7bccc48b8f39)
4. Add the new milkglass-3x3.shader
![Milkglass Shader](https://github.com/user-attachments/assets/ff88b421-1d8b-42da-8695-fae5fa950bf5)
5. Add the crop filter to get the stable color
![Crop Filter](https://github.com/user-attachments/assets/94bd506c-1ee3-4d36-8571-5b4e00fcdb6c)
6. Activate bicubic filtering
![Active Bicubic Scale Filtering](https://github.com/user-attachments/assets/9e5f0e10-1328-4d42-9241-5c0af7a2dc0c)

With this settings you get the end result like in the first image above.